### PR TITLE
Own gulp task for auto-reloading when changes happen

### DIFF
--- a/build/tasks/watch-r.js
+++ b/build/tasks/watch-r.js
@@ -1,0 +1,21 @@
+var gulp = require('gulp');
+var paths = require('../paths');
+var electron = require('electron-connect').server.create();
+
+// outputs changes to files to the console
+function reportChange(event) {
+  console.log('File ' + event.path + ' was ' + event.type + ', running tasks...');
+}
+
+// this task wil watch for changes
+// to js, html, and css files and call the
+// reportChange method.
+gulp.task('watch-r', ['build'], function() {
+  electron.start();
+
+  gulp.watch(paths.source, ['build-system', electron.reload]).on('change', reportChange);
+  gulp.watch('index.js', electron.restart).on('change', reportChange);
+  gulp.watch('index.html', electron.restart).on('change', reportChange);
+  gulp.watch(paths.html, ['build-html', electron.reload]).on('change', reportChange);
+  gulp.watch(paths.less, ['build-less', electron.reload]).on('change', reportChange);
+});

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <title>Aurelia</title>
     <link rel="stylesheet" href="jspm_packages/npm/font-awesome@4.6.3/css/font-awesome.min.css">
     <link rel="stylesheet" href="styles/styles.css">
+    <script>require('electron-connect').client.create()</script>
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
 


### PR DESCRIPTION
To use write ```gulp watch-r``` to lunch the build process with automatic reloading